### PR TITLE
Create account fixes

### DIFF
--- a/src/locales/translations/en.json
+++ b/src/locales/translations/en.json
@@ -519,7 +519,8 @@
 		"fromSeed": "Create from mnemonics seed",
 		"createSeed": "Create seed account",
 		"fromPk": "Create from private key",
-		"createPk": "Create private key account"
+		"createPk": "Create private key account",
+		"errorAccountNameExist": "Account with such name already exists"
 	},
 	"settings": {
 		"logoutConfirmTitle": "Are you sure",

--- a/src/locales/translations/en.json
+++ b/src/locales/translations/en.json
@@ -520,7 +520,9 @@
 		"createSeed": "Create seed account",
 		"fromPk": "Create from private key",
 		"createPk": "Create private key account",
-		"errorAccountNameExist": "Account with such name already exists"
+		"errorAccountNameExist": "Account with such name already exists",
+		"errorPrivateKeyExist": "This account already in the wallet",
+		"errorInvalidPrivateKey": "Invalid private key"
 	},
 	"settings": {
 		"logoutConfirmTitle": "Are you sure",


### PR DESCRIPTION
1. Account name (Resolved: #1)
 - Add check and disallow to create account with the name which already exists in the wallet
 - Show input warning message
2. Private key (Resolved: #6) 
 - Add check and disallow to import the same account twice (Private key import only)
 - Show input warning for ^ and for invalid private key