### PR TITLE
Derivation paths refactor

### DIFF
--- a/env/default.json.example
+++ b/env/default.json.example
@@ -22,7 +22,7 @@
   "nodeTypes": { "MAINNET": "mainnet", "TESTNET": "testnet", "CUSTOM": "custom" },
   "networks": {
     "mainnet": {
-      "nodes": ["http://api.experimental.symboldev.network:3000"]
+      "nodes": []
     },
     "testnet": {
       "nodes": [

--- a/env/default.json.example
+++ b/env/default.json.example
@@ -22,7 +22,7 @@
   "nodeTypes": { "MAINNET": "mainnet", "TESTNET": "testnet", "CUSTOM": "custom" },
   "networks": {
     "mainnet": {
-      "nodes": []
+      "nodes": ["http://api.experimental.symboldev.network:3000"]
     },
     "testnet": {
       "nodes": [

--- a/src/App.js
+++ b/src/App.js
@@ -44,19 +44,19 @@ export const handleAppStateChange = async (nextAppState: any) => {
 
 const initStore = async () => {
     try {
-        store.dispatchAction({ type: 'settings/initState' });
+        await store.dispatchAction({ type: 'settings/initState' });
     } catch {}
     try {
         store.dispatchAction({ type: 'market/loadMarketData' });
     } catch {}
     try {
-        store.dispatchAction({ type: 'network/initState' });
+        await store.dispatchAction({ type: 'network/initState' });
     } catch {}
     try {
         store.dispatchAction({ type: 'news/loadNews' });
     } catch {}
     try {
-        store.dispatchAction({ type: 'addressBook/loadAddressBook' });
+        await store.dispatchAction({ type: 'addressBook/loadAddressBook' });
     } catch {}
 };
 

--- a/src/components/molecules/ConfirmModal/index.js
+++ b/src/components/molecules/ConfirmModal/index.js
@@ -66,7 +66,7 @@ const ConfirmModal = (props: Props) => {
                                 <Section type="button">
                                     <TouchableOpacity onPress={onClose}>
                                         <Text style={{ color: GlobalStyles.color.PRIMARY }} theme="light" type="bold" align="center">
-                                            Cancel
+                                            {translate('Settings.passcode.alertTextCancel')}
                                         </Text>
                                     </TouchableOpacity>
                                 </Section>

--- a/src/components/molecules/ConfirmModal/index.js
+++ b/src/components/molecules/ConfirmModal/index.js
@@ -62,13 +62,15 @@ const ConfirmModal = (props: Props) => {
                             <Section type="form-item">
                                 <Button style={styles.button} title="Confirm" theme="light" fullWidth={false} disabled={confirmDisabled} onPress={onSuccess} />
                             </Section>
-                            <Section type="button">
-                                <TouchableOpacity onPress={onClose}>
-                                    <Text style={{ color: GlobalStyles.color.PRIMARY }} theme="light" type="bold" align="center">
-                                        Cancel
-                                    </Text>
-                                </TouchableOpacity>
-                            </Section>
+                            {onClose && (
+                                <Section type="button">
+                                    <TouchableOpacity onPress={onClose}>
+                                        <Text style={{ color: GlobalStyles.color.PRIMARY }} theme="light" type="bold" align="center">
+                                            Cancel
+                                        </Text>
+                                    </TouchableOpacity>
+                                </Section>
+                            )}
                         </Section>
                     </View>
                 </Card>

--- a/src/components/settings/SettingsNodeSelector.js
+++ b/src/components/settings/SettingsNodeSelector.js
@@ -8,6 +8,7 @@ import { connect } from 'react-redux';
 import store from '@src/store';
 import { getNodes } from '@src/config/environment';
 import GlobalStyles from '@src/styles/GlobalStyles';
+import ConfirmModal from "@src/components/molecules/ConfirmModal";
 
 
 const styles = StyleSheet.create({
@@ -64,7 +65,8 @@ class SettingsNodeSelector extends Component {
         isModalOpen: false,
 		error: null,
 		loading: null,
-		selectedTab: 'mainnet'
+		selectedTab: 'mainnet',
+		isConfirmModalOpen: false,
 	};
 
 	componentDidMount = () => {
@@ -84,6 +86,10 @@ class SettingsNodeSelector extends Component {
             isModalOpen: false,
         });
     };
+
+    onSelectTestnet = () => {
+		this.setState({isConfirmModalOpen: true, selectedTab: 'testnet'});
+	};
 
     onSelectNode = node => {
         this.setState({
@@ -124,7 +130,7 @@ class SettingsNodeSelector extends Component {
             testnet: getNodes('testnet').map(node => ({ value: node, label: node })),
         };
 
-        const { isModalOpen, error, loading, selectedTab } = this.state;
+        const { isModalOpen, error, loading, selectedTab, isConfirmModalOpen } = this.state;
         const { selectedNode, selectedNetwork } = this.props;
 		const list = selectedTab === 'mainnet'
 			? nodes.mainnet
@@ -160,7 +166,7 @@ class SettingsNodeSelector extends Component {
 								</TouchableOpacity>
 								<TouchableOpacity
 									style={styles.tab, selectedTab === 'testnet' && styles.activeTab}
-									onPress={() => this.setState({selectedTab: 'testnet'})}
+									onPress={() => this.onSelectTestnet()}
 								>
 									<Text type="bold" theme="light">
 										Testnet
@@ -212,6 +218,14 @@ class SettingsNodeSelector extends Component {
                         value={selectedNetwork === 'testnet' ? selectedNode : null}
                         onChange={v => this.onSelectNode(v)}
                     /> */}
+
+					<ConfirmModal
+						isModalOpen={isConfirmModalOpen}
+						showTopbar={true}
+						title={translate('settings.logoutConfirm2Title')}
+						text={translate('settings.changeTestnetNode')}
+						onSuccess={() => this.setState({ isConfirmModalOpen: false })}
+					/>
 
                 </PopupModal>
             </View>

--- a/src/locales/translations/en.json
+++ b/src/locales/translations/en.json
@@ -549,6 +549,7 @@
 		"errorInvalidPrivateKey": "Invalid private key"
 	},
 	"settings": {
+		"changeTestnetNode": "You are about to select a testnet node. All transactions done here won't reflect in mainnet network.",
 		"logoutConfirmTitle": "Are you sure",
 		"logoutConfirmDesc": "By logging out the data on the device will be removed. You should have a back up before proceeding",
 		"logoutConfirmCheck": "I have backed up all the accounts under this profile",

--- a/src/screens/AccountDetails.js
+++ b/src/screens/AccountDetails.js
@@ -51,7 +51,7 @@ class AccountDetails extends Component<Props, State> {
 			isPasscodeSelected
 		} = this.props;
 		const { contactQR, isLoading } = this.state;
-        const startPath = "m/44'/4343'/";
+        const startPath = networkType === 'testnet' ? "m/44'/1'/" : "m/44'/4343'/";
         const endPath = "'/0'/0'";
         const seedIndex = path ? path.replace(startPath, '').replace(endPath, '') : null;
 		const data = {

--- a/src/screens/AccountDetails.js
+++ b/src/screens/AccountDetails.js
@@ -14,6 +14,7 @@ import {
 import { Router } from '@src/Router';
 import { connect } from 'react-redux';
 import GlobalStyles from '@src/styles/GlobalStyles';
+import {getAccountIndexFromDerivationPath} from "@src/utils/format";
 
 
 const styles = StyleSheet.create({
@@ -51,10 +52,8 @@ class AccountDetails extends Component<Props, State> {
 			isPasscodeSelected
 		} = this.props;
 		const { contactQR, isLoading } = this.state;
-        const startPath = networkType === 'testnet' ? "m/44'/1'/" : "m/44'/4343'/";
-        const endPath = "'/0'/0'";
-        const seedIndex = path ? path.replace(startPath, '').replace(endPath, '') : null;
-		const data = {
+        const seedIndex = getAccountIndexFromDerivationPath(path, networkType);
+        const data = {
             accountName,
             seedIndex,
             address,

--- a/src/screens/Sidebar.js
+++ b/src/screens/Sidebar.js
@@ -226,7 +226,7 @@ class Sidebar extends Component<Props, State> {
     };
 
     renderSelectedAccountItem = () => {
-        const { address, selectedAccount, balance, nativeMosaicNamespace, isLoading } = this.props;
+        const { address, selectedAccount, balance, nativeMosaicNamespace, isLoading, networkType } = this.props;
         const options = [
             { iconName: 'edit_light', label: translate('sidebar.rename'), onPress: () => this.handleOpenRenameAccountModal(selectedAccount.id, selectedAccount.name) },
             // { iconName: 'delete_light', label: 'Delete', onPress: () => this.handleDeleteAccount(selectedAccount.id) },
@@ -246,7 +246,8 @@ class Sidebar extends Component<Props, State> {
 			: '..';
 
 		const path = selectedAccount.path;
-		const startPath = "m/44'/4343'/";
+        const startPath = networkType === 'testnet' ? "m/44'/1'/" : "m/44'/4343'/";
+		// const startPath = "m/44'/4343'/";
 		const endPath = "'/0'/0'";
 		const index = path ? path.replace(startPath, '').replace(endPath, '') : null;
         return (
@@ -284,6 +285,7 @@ class Sidebar extends Component<Props, State> {
     };
 
     renderAccountSelectorItem = ({ name, balance, address = 'n/a', id, type, path }) => {
+        const { networkType } = this.props;
 		const deleteText = type === 'hd'
 			? translate('sidebar.hide')
 			: translate('sidebar.remove');
@@ -296,7 +298,8 @@ class Sidebar extends Component<Props, State> {
 			? translate('sidebar.hideAccountDescription')
 			: translate('sidebar.removeAccountDescription');
 
-        const startPath = "m/44'/4343'/";
+        // const startPath = "m/44'/4343'/";
+        const startPath = networkType === 'testnet' ? "m/44'/1'/" : "m/44'/4343'/";
         const endPath = "'/0'/0'";
         const index = path ? path.replace(startPath, '').replace(endPath, '') : null;
 
@@ -422,6 +425,7 @@ class Sidebar extends Component<Props, State> {
 export default connect(state => ({
     address: state.account.selectedAccountAddress,
     selectedAccount: state.wallet.selectedAccount,
+    networkType: state.network.selectedNetwork.type,
     balance: state.account.balance,
     nativeMosaicNamespace: 'XYM', //TODO: remove hardcode. state.mosaic.nativeMosaicSubNamespaceName,
     accounts: state.wallet.accounts,

--- a/src/screens/Sidebar.js
+++ b/src/screens/Sidebar.js
@@ -27,6 +27,7 @@ import { downloadFile } from '@src/utils/donwload';
 import ConfirmModal from '@src/components/molecules/ConfirmModal';
 import { showPasscode } from '@src/utils/passcode';
 import translate from "@src/locales/i18n";
+import {getAccountIndexFromDerivationPath} from "@src/utils/format";
 
 const styles = StyleSheet.create({
     root: {
@@ -246,10 +247,7 @@ class Sidebar extends Component<Props, State> {
 			: '..';
 
 		const path = selectedAccount.path;
-        const startPath = networkType === 'testnet' ? "m/44'/1'/" : "m/44'/4343'/";
-		// const startPath = "m/44'/4343'/";
-		const endPath = "'/0'/0'";
-		const index = path ? path.replace(startPath, '').replace(endPath, '') : null;
+        const index = getAccountIndexFromDerivationPath(path, networkType);
         return (
             <SymbolGradientContainer style={styles.selectedAccountBox} noPadding>
                 {/* <Text type="bold" style={styles.selectedIndex}>
@@ -298,10 +296,7 @@ class Sidebar extends Component<Props, State> {
 			? translate('sidebar.hideAccountDescription')
 			: translate('sidebar.removeAccountDescription');
 
-        // const startPath = "m/44'/4343'/";
-        const startPath = networkType === 'testnet' ? "m/44'/1'/" : "m/44'/4343'/";
-        const endPath = "'/0'/0'";
-        const index = path ? path.replace(startPath, '').replace(endPath, '') : null;
+        const index = getAccountIndexFromDerivationPath(path, networkType);
 
         const options = [
             { iconName: 'edit_light', label: translate('sidebar.rename'), onPress: () => this.handleOpenRenameAccountModal(id, name) },

--- a/src/services/AccountService.js
+++ b/src/services/AccountService.js
@@ -7,6 +7,7 @@ import type { MosaicModel } from '@src/storage/models/MosaicModel';
 import { AccountSecureStorage } from '@src/storage/persistence/AccountSecureStorage';
 import MosaicService from '@src/services/MosaicService';
 import { SymbolPaperWallet } from 'symbol-paper-wallets';
+import {getAccountIndexFromDerivationPath} from "@src/utils/format";
 
 export default class AccountService {
     /**
@@ -42,22 +43,16 @@ export default class AccountService {
         const accounts = await AccountSecureStorage.getAllAccountsByNetwork(network);
         const hdAccounts = accounts.filter(el => el.type === 'hd' && el.path);
         hdAccounts.sort((a, b) => {
-            const aI = this.getIndexFromAccountModel(a) || -1;
-            const bI = this.getIndexFromAccountModel(b) || -1;
+            const aI = getAccountIndexFromDerivationPath(a.path, a.network) || -1;
+            const bI = getAccountIndexFromDerivationPath(b.path, b.network) || -1;
             return aI - bI;
         });
         let lastIndex = 0;
         for (let account: AccountModel of hdAccounts) {
-            const index = this.getIndexFromAccountModel(account);
+            const index = getAccountIndexFromDerivationPath(account.path, account.network);
             if (index === lastIndex) lastIndex = index + 1;
         }
         return lastIndex;
-    }
-
-    static getIndexFromAccountModel(account: AccountModel): number | null {
-        const startPath = account.network === 'testnet' ? "m/44'/1'/" : "m/44'/4343'/";
-        const endPath = "'/0'/0'";
-        return account.path ? parseInt(account.path.replace(startPath, '').replace(endPath, '')) : null;
     }
 
     /**

--- a/src/services/AccountService.js
+++ b/src/services/AccountService.js
@@ -35,44 +35,60 @@ export default class AccountService {
     static getAddressByAccountModelAndNetwork(accountModel: AccountModel, network: AppNetworkType): string {
         return Account.createFromPrivateKey(accountModel.privateKey, this._appNetworkToNetworkType(network)).address.pretty();
     }
+    /**
+     * Generates random mnemonic
+     */
+    static async getNextIndex(network: AppNetworkType): number {
+        const accounts = await AccountSecureStorage.getAllAccountsByNetwork(network);
+        const hdAccounts = accounts.filter(el => el.type === 'hd' && el.path);
+        hdAccounts.sort((a, b) => {
+            const aI = this.getIndexFromAccountModel(a) || -1;
+            const bI = this.getIndexFromAccountModel(b) || -1;
+            return aI - bI;
+        });
+        let lastIndex = 0;
+        for (let account: AccountModel of hdAccounts) {
+            const index = this.getIndexFromAccountModel(account);
+            if (index === lastIndex) lastIndex = index + 1;
+        }
+        return lastIndex;
+    }
+
+    static getIndexFromAccountModel(account: AccountModel): number | null {
+        const startPath = account.network === 'testnet' ? "m/44'/1'/" : "m/44'/4343'/";
+        const endPath = "'/0'/0'";
+        return account.path ? parseInt(account.path.replace(startPath, '').replace(endPath, '')) : null;
+    }
 
     /**
      * Remove account by it's id
      */
-    static async removeAccountById(id: string): string {
-        const allAccounts = await AccountSecureStorage.getAllAccounts();
-        const filteredAccounts = allAccounts.filter(account => account.id !== id);
-        await AccountSecureStorage.saveAccounts(filteredAccounts);
-        return filteredAccounts;
+    static async removeAccountById(id: string, network: AppNetworkType): string {
+        return AccountSecureStorage.removeAccount(id, network);
     }
 
     /**
      * Renames account by it's id
      */
-    static async renameAccount(id: string, newName: string): string {
-        const allAccounts = await AccountSecureStorage.getAllAccounts();
-        allAccounts.forEach(account => {
-            if (account.id === id) {
-                account.name = newName;
-            }
-        });
-        await AccountSecureStorage.saveAccounts(allAccounts);
-        return allAccounts;
+    static async renameAccount(id: string, newName: string, network: AppNetworkType): string {
+        const allAccounts = await AccountSecureStorage.getAllAccountsByNetwork(network);
+        const account = allAccounts.find(account => account.id === id);
+        account.name = newName;
+        await AccountSecureStorage.updateAccount(account);
+        return AccountSecureStorage.getAllAccountsByNetwork(network);
     }
 
     /**
      * Updates persistent del request sent
      */
-    static async updateDelegatedHarvestingInfo(id: string, isPersistentDelReqSent: boolean, harvestingNode: string): string {
-        const allAccounts = await AccountSecureStorage.getAllAccounts();
-        allAccounts.forEach(account => {
-            if (account.id === id) {
-                account.isPersistentDelReqSent = isPersistentDelReqSent;
-                account.harvestingNode = harvestingNode;
-            }
-        });
-        await AccountSecureStorage.saveAccounts(allAccounts);
-        return allAccounts;
+    static async updateDelegatedHarvestingInfo(id: string, isPersistentDelReqSent: boolean, harvestingNode: string, network: AppNetworkType): string {
+        const allAccounts = await AccountSecureStorage.getAllAccountsByNetwork(network);
+        const account = allAccounts.find(account => account.id === id);
+        if (!account) return;
+        account.isPersistentDelReqSent = isPersistentDelReqSent;
+        account.harvestingNode = harvestingNode;
+        await AccountSecureStorage.updateAccount(account);
+        return AccountSecureStorage.getAllAccountsByNetwork(network);
     }
 
     /**
@@ -80,16 +96,17 @@ export default class AccountService {
      * @param mnemonic
      * @param index
      * @param name
+     * @param network
      * @returns {AccountModel}
      */
-    static createFromMnemonicAndIndex(mnemonic: string, index: number, name: string): AccountModel {
+    static createFromMnemonicAndIndex(mnemonic: string, index: number, name: string, network: AppNetworkType): AccountModel {
         const mnemonicPassPhrase = new MnemonicPassPhrase(mnemonic);
         const seed = mnemonicPassPhrase.toSeed().toString('hex');
         const extKey = ExtendedKey.createFromSeed(seed);
         const wallet = new Wallet(extKey);
-        const path = `m/44'/4343'/${index}'/0'/0'`;
+        const path = `m/44'/${network === 'testnet' ? '1' : '4343'}'/${index}'/0'/0'`;
         const privateKey = wallet.getChildAccountPrivateKey(path);
-        const symbolAccount = Account.createFromPrivateKey(privateKey, NetworkType.MAIN_NET);
+        const symbolAccount = Account.createFromPrivateKey(privateKey, network === 'testnet' ? NetworkType.TEST_NET : NetworkType.MAIN_NET);
         return this.symbolAccountToAccountModel(symbolAccount, name, 'hd', path);
     }
 
@@ -97,10 +114,11 @@ export default class AccountService {
      * Creates an account from a mnemonic
      * @param privateKey
      * @param name
+     * @param network
      * @returns {AccountModel}
      */
-    static createFromPrivateKey(privateKey: string, name: string): AccountModel {
-        const symbolAccount = Account.createFromPrivateKey(privateKey, NetworkType.MAIN_NET);
+    static createFromPrivateKey(privateKey: string, name: string, network: AppNetworkType): AccountModel {
+        const symbolAccount = Account.createFromPrivateKey(privateKey, network === 'testnet' ? NetworkType.TEST_NET : NetworkType.MAIN_NET);
         return this.symbolAccountToAccountModel(symbolAccount, name, 'privateKey');
     }
 
@@ -176,6 +194,7 @@ export default class AccountService {
             type: type,
             privateKey: account.privateKey,
             path: path,
+            network: account.networkType === NetworkType.TEST_NET ? 'testnet' : 'mainnet',
         };
     }
 
@@ -204,7 +223,7 @@ export default class AccountService {
      * @param network
      */
     static async generatePaperWallet(mnemonic: string, accounts: AccountModel[], network: NetworkModel): Promise<Uint8Array> {
-        const mnemonicAccount = this.createFromMnemonicAndIndex(mnemonic, 0, 'Root');
+        const mnemonicAccount = this.createFromMnemonicAndIndex(mnemonic, 0, 'Root', network.type);
         const hdRootAccount = {
             mnemonic: mnemonic,
             rootAccountPublicKey: mnemonicAccount.id,

--- a/src/services/NetworkService.js
+++ b/src/services/NetworkService.js
@@ -1,4 +1,4 @@
-import { ChainHttp, NetworkConfiguration, NetworkHttp, NetworkType, NodeHttp } from 'symbol-sdk';
+import {ChainHttp, NetworkConfiguration, NetworkHttp, NetworkType, NodeHttp, TransactionFees} from 'symbol-sdk';
 import type { NetworkModel } from '@src/storage/models/NetworkModel';
 import { durationStringToSeconds } from '@src/utils/format';
 import { timeout } from 'rxjs/operators';
@@ -26,10 +26,15 @@ export default class NetworkService {
             .getChainInfo()
             .pipe(timeout(REQUEST_TIMEOUT))
             .toPromise();
-        const transactionFees = await networkHttp
-            .getTransactionFees()
-            .pipe(timeout(REQUEST_TIMEOUT))
-            .toPromise();
+        let transactionFees: TransactionFees;
+        try {
+            transactionFees = await networkHttp
+                .getTransactionFees()
+                .pipe(timeout(REQUEST_TIMEOUT))
+                .toPromise();
+        } catch (e) {
+            transactionFees = new TransactionFees(0, 0, 0, 0, 0);
+        }
 
         return {
             type: networkType === NetworkType.TEST_NET ? 'testnet' : 'mainnet',

--- a/src/storage/models/AccountModel.js
+++ b/src/storage/models/AccountModel.js
@@ -1,6 +1,8 @@
 /**
  * Account Origin Type
  */
+import type {AppNetworkType} from "@src/storage/models/NetworkModel";
+
 export type AccountOriginType = 'hd' | 'privateKey';
 
 /**
@@ -12,6 +14,7 @@ export interface AccountModel {
     type: AccountOriginType;
     path?: string;
     privateKey: string;
+    network: AppNetworkType;
     isPersistentDelReqSent: boolean;
     harvestingNode: string;
 }

--- a/src/storage/persistence/AccountSecureStorage.js
+++ b/src/storage/persistence/AccountSecureStorage.js
@@ -1,5 +1,6 @@
 import { BaseSecureStorage } from '@src/storage/persistence/BaseSecureStorage';
 import type { AccountModel } from '@src/storage/models/AccountModel';
+import type {AppNetworkType} from "@src/storage/models/NetworkModel";
 
 export class AccountSecureStorage extends BaseSecureStorage {
     /** ACCOUNTS DB KEY **/
@@ -12,10 +13,10 @@ export class AccountSecureStorage extends BaseSecureStorage {
      */
     static async createNewAccount(account: AccountModel): Promise<AccountModel> {
         const accounts = await this.getAllAccounts();
-        if (!accounts.find(el => el.id === account.id)) {
+        if (!accounts.find(el => el.id === account.id && el.network === account.network)) {
             accounts.push(account);
         }
-        return this.secureSaveAsync(this.ACCOUNTS_KEY, JSON.stringify(accounts));
+        return this.saveAccounts(accounts);
     }
 
     /**
@@ -28,8 +29,38 @@ export class AccountSecureStorage extends BaseSecureStorage {
     }
 
     /**
-     * Get all the accounts
-     * @returns {Promise<AccountModel[]>}
+     * Updates account
+     * @param newAccount
+     * @returns {Promise<*>}
+     */
+    static async updateAccount(newAccount: AccountModel): Promise<any> {
+        const allAccounts = await this.getAllAccounts();
+        const edited = allAccounts.map(account => {
+            if (account.id === newAccount.id) {
+                return newAccount;
+            } else {
+                return account;
+            }
+        });
+        return this.saveAccounts(edited);
+    }
+
+    /**
+     * Removes an account by its id and network
+     * @param id
+     * @param network
+     * @returns {Promise<*>}
+     */
+    static async removeAccount(id: string, network: AppNetworkType): Promise<AccountModel[]> {
+        const allAccounts = await this.getAllAccounts();
+        const filteredAccounts = allAccounts.filter(account => !(account.id === id && account.network === network));
+        await this.saveAccounts(filteredAccounts);
+        return filteredAccounts;
+    }
+
+    /**
+     * Returns all accounts
+     * @returns {Promise<void>}
      */
     static async getAllAccounts(): Promise<AccountModel[]> {
         const accountsString = await this.secureRetrieveAsync(this.ACCOUNTS_KEY);
@@ -44,14 +75,17 @@ export class AccountSecureStorage extends BaseSecureStorage {
      * Get all the accounts
      * @returns {Promise<AccountModel[]>}
      */
-    static async getAccountById(id: number): Promise<AccountModel | null> {
-        const accountsString = await this.secureRetrieveAsync(this.ACCOUNTS_KEY);
-        let accounts;
-        try {
-            accounts = JSON.parse(accountsString) || [];
-        } catch (e) {
-            return null;
-        }
+    static async getAllAccountsByNetwork(network: AppNetworkType): Promise<AccountModel[]> {
+        const allAccounts = await this.getAllAccounts();
+        return allAccounts.filter(el => el.network === network);
+    }
+
+    /**
+     * Get all the accounts
+     * @returns {Promise<AccountModel[]>}
+     */
+    static async getAccountById(id: number, network: AppNetworkType): Promise<AccountModel | null> {
+        const accounts = await this.getAllAccountsByNetwork(network);
         return accounts.find(account => account.id === id);
     }
 

--- a/src/store/network.js
+++ b/src/store/network.js
@@ -77,7 +77,7 @@ export default {
             commit({ type: 'network/setSelectedNode', payload: payload });
             commit({ type: 'network/setIsLoaded', payload: true });
             GlobalListener.setNetwork(network);
-            await dispatchAction({ type: 'account/loadAllData' });
+            await dispatchAction({ type: 'wallet/initState' });
         },
         updateChainHeight: async ({ state, commit }, payload) => {
             const selectedNetwork = state.network.selectedNetwork;

--- a/src/utils/DataSchemaMigrations.js
+++ b/src/utils/DataSchemaMigrations.js
@@ -4,13 +4,17 @@ import Account from "@src/utils/storage/models/Account";
 import {AccountSecureStorage} from "@src/storage/persistence/AccountSecureStorage";
 import AccountService from "@src/services/AccountService";
 import {MnemonicSecureStorage} from "@src/storage/persistence/MnemonicSecureStorage";
+import type {AccountModel} from "@src/storage/models/AccountModel";
 
-export const CURRENT_DATA_SCHEMA = 1;
+export const CURRENT_DATA_SCHEMA = 2;
 
 export const migrateDataSchema = async (oldVersion: number) => {
     switch (oldVersion) {
         case 0:
             await migrateVersion0();
+            break;
+        case 1:
+            await migrateVersion1();
             break;
     }
     await AsyncCache.setDataSchemaVersion(CURRENT_DATA_SCHEMA);
@@ -19,9 +23,27 @@ export const migrateDataSchema = async (oldVersion: number) => {
 const migrateVersion0 = async () => {
     console.log('Migrating from version 0');
     const mnemonicModel = await MnemonicSecureStorage.retrieveMnemonic();
+    if (!mnemonicModel) return;
     const accounts = await getLocalAccounts().toPromise();
     for (let account: Account of accounts) {
-        const newAccountModel = AccountService.createFromMnemonicAndIndex(mnemonicModel.mnemonic, account.bipIndex, account.name);
+        const newAccountModel = AccountService.createFromMnemonicAndIndex(mnemonicModel.mnemonic, account.bipIndex, account.name, 'mainnet');
         await AccountSecureStorage.createNewAccount(newAccountModel);
     }
+    const newAccountModel = AccountService.createFromMnemonicAndIndex(mnemonicModel.mnemonic, 0, 'Root account', 'testnet');
+    await AccountSecureStorage.createNewAccount(newAccountModel);
+};
+
+const migrateVersion1 = async () => {
+    console.log('Migrating from version 1');
+    const mnemonicModel = await MnemonicSecureStorage.retrieveMnemonic();
+    const accounts = await AccountSecureStorage.getAllAccounts();
+    for (let account: AccountModel of accounts) {
+        await AccountSecureStorage.updateAccount({
+            ...account,
+            network: 'testnet',
+            type: 'privateKey',
+        });
+    }
+    const newAccountModel = AccountService.createFromMnemonicAndIndex(mnemonicModel.mnemonic, 0, 'Root account', 'mainnet');
+    await AccountSecureStorage.createNewAccount(newAccountModel);
 };

--- a/src/utils/format.js
+++ b/src/utils/format.js
@@ -1,5 +1,6 @@
 import { LocalDate, LocalDateTime } from 'js-joda';
 import translate from '@src/locales/i18n';
+import type {AppNetworkType} from "@src/storage/models/NetworkModel";
 
 export const formatTransactionLocalDateTime = (dt: LocalDateTime): string => {
     return `${dt.dayOfMonth()}/${dt.monthValue()}/${dt.year()}`;
@@ -110,4 +111,10 @@ export const durationToRelativeTime = (durationInBlocks: number, blockGeneration
 
 export const shortifyAddress = (address: string): string => {
     return `${address.slice(0, 6)}-...-${address.slice(42)}`;
+};
+
+export const getAccountIndexFromDerivationPath = (path: string, network: AppNetworkType): number => {
+    const startPath = network === 'testnet' ? "m/44'/1'/" : "m/44'/4343'/";
+    const endPath = "'/0'/0'";
+    return path ? parseInt(path.replace(startPath, '').replace(endPath, '')) : null;
 };


### PR DESCRIPTION
AccountModel now is linked to a network. 
When changing the network accounts / private keys will be different.

- New testnet derivation path:  "m/44'/1'/${index}'/0'/0'"
- New mainnet derivation path:  "m/44'/4343'/${index}'/0'/0'"

Added mainnet experimental node: "http://api.experimental.symboldev.network:3000"

